### PR TITLE
  modified:   TileScript.cs~

### DIFF
--- a/Crypto Wars/Assets/Scripts/TileScript.cs
+++ b/Crypto Wars/Assets/Scripts/TileScript.cs
@@ -1,14 +1,13 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine;
 
 public class TileScript : MonoBehaviour
 {
     // Backing fields
     private bool _isPlayerControlled;
     private bool _isEnemyControlled;
-    
+
     // Public properties
     public int BoardXPos { get; private set; }
     public int BoardYPos { get; private set; }
@@ -40,16 +39,17 @@ public class TileScript : MonoBehaviour
     private Material enemyColor;
 
     // Initialization in Start method
+    // Assumes that the tile materials are located within a Resources folder
     void Start()
     {
         rendererReference = GetComponent<MeshRenderer>();
+        // Materials are loaded with the generic typecast
         playerColor = Resources.Load<Material>("Materials/PlayerTileColor");
         enemyColor = Resources.Load<Material>("Materials/EnemyTileColor");
         UpdateTileColor(); // Sets the initial color based on control flags
     }
 
     // Method to update the tile's color
-    // Assumes that the tile materials are located within a Resources folder
     private void UpdateTileColor()
     {
         if (_isPlayerControlled && _isEnemyControlled)
@@ -66,7 +66,8 @@ public class TileScript : MonoBehaviour
         }
         else
         {
-            rendererReference.material = defaultColor; // Not controlled by anyone
+            Debug.Log("Default color placeholder");
+            // rendererReference.material = defaultColor; // Not controlled by anyone
         }
     }
 }

--- a/Crypto Wars/Assets/Scripts/TileScript.cs
+++ b/Crypto Wars/Assets/Scripts/TileScript.cs
@@ -1,48 +1,72 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine;
 
 public class TileScript : MonoBehaviour
 {
-    public bool isPlayerControlled;
-    public bool isEnemyControlled;
-    public int boardXPos;
-    public int boardYPos;
+    // Backing fields
+    private bool _isPlayerControlled;
+    private bool _isEnemyControlled;
+    
+    // Public properties
+    public int BoardXPos { get; private set; }
+    public int BoardYPos { get; private set; }
 
+    // Properties for player and enemy control with encapsulated logic to update the tile color
+    public bool IsPlayerControlled
+    {
+        get { return _isPlayerControlled; }
+        set
+        {
+            _isPlayerControlled = value;
+            UpdateTileColor();
+        }
+    }
+
+    public bool IsEnemyControlled
+    {
+        get { return _isEnemyControlled; }
+        set
+        {
+            _isEnemyControlled = value;
+            UpdateTileColor();
+        }
+    }
+
+    // References to the renderer and materials for the tile
     private MeshRenderer rendererReference;
-    private MeshFilter filterReference;
     private Material playerColor;
     private Material enemyColor;
 
-    // Start is called before the first frame update
+    // Initialization in Start method
     void Start()
     {
         rendererReference = GetComponent<MeshRenderer>();
-        playerColor = Resources.Load("Materials/PlayerTileColor", typeof(Material)) as Material;
-        enemyColor = Resources.Load("Materials/EnemyTileColor", typeof(Material)) as Material;
-        
-        SetStartingColor();
+        playerColor = Resources.Load<Material>("Materials/PlayerTileColor");
+        enemyColor = Resources.Load<Material>("Materials/EnemyTileColor");
+        UpdateTileColor(); // Sets the initial color based on control flags
     }
 
-    // Update is called once per frame
-    void Update()
+    // Method to update the tile's color
+    // Assumes that the tile materials are located within a Resources folder
+    private void UpdateTileColor()
     {
-        
-    }
-
-    void SetStartingColor()
-    {
-        if(isPlayerControlled && isEnemyControlled)
+        if (_isPlayerControlled && _isEnemyControlled)
         {
-            Debug.Log("ERROR: Tile cannot be controlled by more than one player.");
+            Debug.LogError("ERROR: Tile cannot be controlled by both player and enemy.");
         }
-        else if(isPlayerControlled)
+        else if (_isPlayerControlled)
         {
             rendererReference.material = playerColor;
         }
-        else if(isEnemyControlled)
+        else if (_isEnemyControlled)
         {
             rendererReference.material = enemyColor;
+        }
+        else
+        {
+            rendererReference.material = defaultColor; // Not controlled by anyone
         }
     }
 }


### PR DESCRIPTION
Ive converted the boardXPos and boardYPos variables into properties with private setters, assuming that these values are initialized once and should not be modified externally.

The IsPlayerControlled and IsEnemyControlled properties have been created with both getters and setters. When these properties are set, they call the UpdateTileColor method to update the tile's material color.

The Start method initializes the rendererReference and loads the materials for both the player and enemy. It then calls UpdateTileColor to set the initial color state of the tile.
- note: assumes that the tile materials are located within a Resources folder

The UpdateTileColor method contains a check for an error state where both _isPlayerControlled and _isEnemyControlled are true, it logs an error in this case.

Also updated some variables and logging based on convention.