### PR TITLE
Added GUI for list of players

### DIFF
--- a/Crypto Wars/Assets/Scripts/GUI/PlayerList.cs
+++ b/Crypto Wars/Assets/Scripts/GUI/PlayerList.cs
@@ -14,16 +14,11 @@ public class PlayerList : MonoBehaviour
     void Start()
     {
         TMP_FontAsset font = Resources.Load<TMP_FontAsset>("LiberationSans.ttf");
-        // create a UI 'Canvas' via code
-        GameObject PlayerList = new GameObject("PlayerList");
-        Canvas canvas = PlayerList.AddComponent<Canvas>();
-        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-        PlayerList.AddComponent<CanvasScaler>();
-        PlayerList.AddComponent<GraphicRaycaster>();
+        GameObject Canvas = GameObject.Find("Canvas");
 
         // create the panel which displays all needed information
         GameObject panel = new GameObject("Panel");
-        panel.transform.parent = PlayerList.transform;
+        panel.transform.parent = Canvas.transform;
         panel.AddComponent<CanvasRenderer>();
         Image image = panel.AddComponent<Image>();
         image.color = new Color(0, 0, 0, 0.5f);
@@ -37,7 +32,7 @@ public class PlayerList : MonoBehaviour
         // add text to panel
         GameObject temp = new GameObject("Player1_Text");
         TextMeshProUGUI player1 = temp.AddComponent<TextMeshProUGUI>();
-        player1.transform.parent = PlayerList.transform;
+        player1.transform.parent = Canvas.transform;
             // align text within panel
         player1.GetComponent<RectTransform>().localPosition = Vector3.zero;
         player1.GetComponent<RectTransform>().anchorMin = new Vector2(1, 0.5f);

--- a/Crypto Wars/Assets/Scripts/GUI/PlayerList.cs
+++ b/Crypto Wars/Assets/Scripts/GUI/PlayerList.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEditor.SearchService;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class PlayerList : MonoBehaviour
+{
+    public PlayerController Controller;
+
+    // Start is called before the first frame update
+    /* Start creates all objects and components needed to create */
+    void Start()
+    {
+        TMP_FontAsset font = Resources.Load<TMP_FontAsset>("LiberationSans.ttf");
+        // create a UI 'Canvas' via code
+        GameObject PlayerList = new GameObject("PlayerList");
+        Canvas canvas = PlayerList.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        PlayerList.AddComponent<CanvasScaler>();
+        PlayerList.AddComponent<GraphicRaycaster>();
+
+        // create the panel which displays all needed information
+        GameObject panel = new GameObject("Panel");
+        panel.transform.parent = PlayerList.transform;
+        panel.AddComponent<CanvasRenderer>();
+        Image image = panel.AddComponent<Image>();
+        image.color = new Color(0, 0, 0, 0.5f);
+
+        // fix panel position to middle right of screen
+        panel.GetComponent<RectTransform>().localPosition = Vector3.zero;
+        panel.GetComponent<RectTransform>().anchorMin = new Vector2(1, 0.5f);
+        panel.GetComponent<RectTransform>().anchorMax = new Vector2(1, 0.5f);
+        panel.GetComponent<RectTransform>().pivot = new Vector2(1, 0.5f);
+
+        // add text to panel
+        GameObject temp = new GameObject("Player1_Text");
+        TextMeshProUGUI player1 = temp.AddComponent<TextMeshProUGUI>();
+        player1.transform.parent = PlayerList.transform;
+            // align text within panel
+        player1.GetComponent<RectTransform>().localPosition = Vector3.zero;
+        player1.GetComponent<RectTransform>().anchorMin = new Vector2(1, 0.5f);
+        player1.GetComponent<RectTransform>().anchorMax = new Vector2(1, 0.5f);
+        player1.GetComponent<RectTransform>().pivot = new Vector2(1, 0.5f);
+        player1.GetComponent<RectTransform>().sizeDelta = new Vector2(95, 50);
+            // change how text is displayed
+        player1.text = "Player 1 \t <info>";
+        player1.color = Color.blue;
+        player1.font = font;
+        player1.fontSize = 10;
+    }
+
+    // Update is called once per frame
+    /* Update() should be used to change any displayed text during the game */
+    void Update()
+    {
+        
+    }
+}

--- a/Crypto Wars/Assets/Scripts/GUI/PlayerList.cs.meta
+++ b/Crypto Wars/Assets/Scripts/GUI/PlayerList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac0361c123b37714c8290792991133ce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds baseline GUI for list of players shown during gameplay. Creates all necessary Unity objects and components needed to show a player, their color, and any information such as player score. Currently the script only adds text for 'Player 1' and cannot be removed from the view during gameplay. More work will need to be done on this GUI element in order  for the project to meet the status of a 'Minimum Viable Product'. 

Features which should be added in a future PR include:
- Add all players to the panel
- Change color of text displayed to color of the player
- Change text to display important information such as player score
- Add/Remove this GUI element from view during gameplay