### PR TITLE
Added in BuildingRegistry and updated Building Class

### DIFF
--- a/Crypto Wars/Assets/Scripts/Building.cs
+++ b/Crypto Wars/Assets/Scripts/Building.cs
@@ -11,6 +11,15 @@ public class Building
     private Card producedCard;
     private Player owner;
     private Tile currentTile;
+    private string name;
+
+    public Building(string nme, int amt, int ttProduce)
+    {
+        name = nme;
+        amount = amt;
+        turnsToProduce = ttProduce;
+        turnsSinceLastProdction = 0;
+    }
 
     public Player getOwner()
     {
@@ -45,6 +54,16 @@ public class Building
     public void setAmount(int inAmount)
     {
         amount = inAmount;
+    }
+
+    public void setCard(Card cardProd)
+    {
+        producedCard = cardProd;
+    }
+
+    public string getName()
+    {
+        return name;
     }
 
     private void addCardsToInventory()

--- a/Crypto Wars/Assets/Scripts/buildingRegistry.cs
+++ b/Crypto Wars/Assets/Scripts/buildingRegistry.cs
@@ -1,30 +1,35 @@
-// // Represents a building capable of producing units.
-// public class BuildingRegistry
-// {
-//     // The name of the building.
-//     public string Name { get; private set; }
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
 
-//     // Constructor to create a new building with a specified name.
-//     public Building(string name)
-//     {
-//         Name = name;
-//     }
+public class BuildingRegistry : MonoBehaviour
+{
+    // List of building types and grabs the card they produce from the card registry
+    private List<Building> buildingList;
+    private CardRegistry cList;
 
-//     // Produces a unit card based on the specified unit type.
-//     public Card ProduceUnit(UnitType unitType)
-//     {
-//         // Determines the unit to produce based on the unit type.
-//         switch (unitType)
-//         {
-//             case UnitType.Light:
-//                 return new Card(UnitType.Light, "Light Unit", 100);
-//             case UnitType.Medium:
-//                 return new Card(UnitType.Medium, "Medium Unit", 200);
-//             case UnitType.Heavy:
-//                 return new Card(UnitType.Heavy, "Heavy Unit", 300);
-//             default:
-//                 // Throws an exception if the unit type is not recognized.
-//                 throw new ArgumentOutOfRangeException(nameof(unitType), $"Not expected unit type value: {unitType}");
-//         }
-//     }
-// }
+    // Initialized after cardRegistry since CreateBuilding relies on it
+    void Start() 
+    {
+        // Create buildings that produces the cards
+        CreateBuilding("Python Factory", "Python", 1, 3);
+        CreateBuilding("Java Junction", "Java", 2, 5);
+        CreateBuilding("C Workshop", "C", 1, 3);
+    }
+
+    // Creates the bulding types and adds them to buildingList
+    void CreateBuilding(string name, string cardName, int numProduced, int turnsToProduce)
+    {
+        Building newBuild = new Building(name, numProduced, turnsToProduce);
+        Card cardProduct = cList.GetCardByName(cardName);  
+        newBuild.setCard(cardProduct);
+
+        buildingList.Add(newBuild);
+    }
+
+    // Grabs building from the list by name
+    public Building GetBuildingByName(string buildingName)
+    {
+        return buildingList.Find(build => build.getName() == buildingName);
+    }
+}

--- a/Crypto Wars/Assets/Scripts/cardRegistry.cs
+++ b/Crypto Wars/Assets/Scripts/cardRegistry.cs
@@ -6,8 +6,8 @@ public class CardRegistry : MonoBehaviour
     // A list to hold all the cards
     private List<Card> cardList = new List<Card>();
 
-    // Start is called before the first frame update
-    void Start()
+    // Initialized before buildingRegistry
+    void Awake()
     {
         // Create the cards
         CreateCard("Python", 100, 150, 20);


### PR DESCRIPTION
#28  This is the second half of issue 28 focused on the buildingRegistry class and adding in a constructor for buildings. After the cards list in cardRegistry is initialized during Awake(), buildingRegistry initializes the buildings for them during Start(). They are also added into a list and grabbed by their name. 