### PR TITLE
Tile interaction - Building Menu & Minor Enhancements

### DIFF
--- a/Crypto Wars/Assets/Prefabs/GameController.prefab
+++ b/Crypto Wars/Assets/Prefabs/GameController.prefab
@@ -9,7 +9,6 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5286370931497955039}
-  - component: {fileID: 7151415334601769360}
   m_Layer: 0
   m_Name: GameController
   m_TagString: Untagged
@@ -32,18 +31,3 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &7151415334601769360
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1448950611362885455}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f33ce358a22a4e44f820d3f5ed86fe98, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  TilePrefab: {fileID: 4925453438323317123, guid: 31d68e7889dc7a34e996db8116aea38b, type: 3}
-  boardWidth: 0
-  boardHeight: 0

--- a/Crypto Wars/Assets/Prefabs/Tile.prefab
+++ b/Crypto Wars/Assets/Prefabs/Tile.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: -8736652913548026287}
   - component: {fileID: -155063383111688805}
   - component: {fileID: 67492345171642944}
+  - component: {fileID: -1064972619964178924}
   m_Layer: 0
   m_Name: Tile
   m_TagString: Untagged
@@ -96,7 +97,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2c768ede4cfbb0441865406a4c5adc90, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isPlayerControlled: 0
-  isEnemyControlled: 0
-  boardXPos: 0
-  boardYPos: 0
+--- !u!65 &-1064972619964178924
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4925453438323317123}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Crypto Wars/Assets/Scripts/GUI/BuildButtonScript.cs
+++ b/Crypto Wars/Assets/Scripts/GUI/BuildButtonScript.cs
@@ -1,0 +1,193 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;                        //
+using UnityEditor.SearchService;    //
+using UnityEngine;
+using UnityEngine.UI;
+
+public class BuildButtonScript : MonoBehaviour
+{
+    // public GameObject buildOptionsMenu;
+    public GameObject destroyButton;
+    public GameObject buildButton;
+    public GameObject cancelButton;
+    // Start is called before the first frame update
+    void Start()
+    {
+        CreateDestroyButton();
+        CreateBuildButton();
+        CreateCancelButton();
+
+        if (Input.GetKeyDown(KeyCode.M)) {
+            Debug.Log("Toggling Building Menu");
+            ToggleMenu();
+        }
+        // NOTE: I also created a canvas with a button in it, which is not reflected here
+
+        // TMP_FontAsset font = Resources.Load<TMP_FontAsset>("LiberationSans.ttf");
+
+        // buildOptionsMenu = new GameObject("Build Options", typeof(CanvasRenderer));
+        // buildOptionsMenu.transform.parent = GameObject.Find("Canvas").transform;
+        // // buildOptionsMenu.AddComponent<CanvasRenderer>();
+        // Image image = buildOptionsMenu.AddComponent<Image>();
+        // image.color = new Color(0, 0, 0, 0.5f);
+        
+        // buildOptionsMenu.GetComponent<RectTransform>().localPosition = Vector3.zero;
+        // buildOptionsMenu.GetComponent<RectTransform>().anchorMin = new Vector2(0, 0.5f);
+        // buildOptionsMenu.GetComponent<RectTransform>().anchorMax = new Vector2(0, 0.5f);
+        // buildOptionsMenu.GetComponent<RectTransform>().pivot = new Vector2(0, 0.5f);
+
+        // GameObject temp = new GameObject("Building1_Text");
+        // TextMeshProUGUI building1 = temp.AddComponent<TextMeshProUGUI>();
+        // building1.transform.parent = buildOptionsMenu.transform;
+
+        // building1.GetComponent<RectTransform>().localPosition = Vector3.zero;
+        // building1.GetComponent<RectTransform>().anchorMin = new Vector2(0, 0.5f);
+        // building1.GetComponent<RectTransform>().anchorMax = new Vector2(0, 0.5f);
+        // building1.GetComponent<RectTransform>().pivot = new Vector2(0, 0.5f);
+        // building1.GetComponent<RectTransform>().sizeDelta = new Vector2(95, 50);
+
+        // building1.text = "\t\t Building 1";
+        // building1.font = font;
+        // building1.fontSize = 10;
+
+        // GameObject temp2 = new GameObject("Building2_Button");
+        // Button building2 = temp2.AddComponent<Button>();
+        // // Image image2 = building2.AddComponent<Image>();
+        // building2.transform.parent = buildOptionsMenu.transform;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+
+    }
+
+    public void CreateBuildButton()
+    {
+        GameObject buildButton = new GameObject("BuildButton");
+        buildButton.transform.parent = GameObject.Find("Canvas").transform;
+
+        buildButton.AddComponent<Image>();
+        buildButton.GetComponent<Image>().color = new Color(0, 255, 0, 255);
+        // Image destroyImage = destroyButton.GetComponent<Image>();
+        // destroyImage.type = Image.Type.Sliced;
+
+        buildButton.AddComponent<Button>();
+        buildButton.GetComponent<RectTransform>().localPosition = Vector3.zero;
+        buildButton.GetComponent<RectTransform>().anchorMin = new Vector2(0, 0.6f); //0.6f
+        buildButton.GetComponent<RectTransform>().anchorMax = new Vector2(0, 0.6f);
+        buildButton.GetComponent<RectTransform>().pivot = new Vector2(0, 0.6f);
+        buildButton.GetComponent<RectTransform>().sizeDelta = new Vector2(100, 30);
+        
+        GameObject buildButtonText = new GameObject("BuildButtonText");
+        TextMeshProUGUI buildText = buildButtonText.AddComponent<TextMeshProUGUI>();
+        buildText.transform.parent = buildButton.transform;
+
+        buildText.text = "\tBuild";
+        buildText.color = new Color(0, 0, 0, 255);
+        buildText.fontSize = 15;
+
+        buildText.GetComponent<RectTransform>().localPosition = Vector3.zero;
+        buildText.GetComponent<RectTransform>().anchorMin = new Vector2(0.1f, 1.3f);
+        buildText.GetComponent<RectTransform>().anchorMax = new Vector2(0.1f, 1.3f);
+        buildText.GetComponent<RectTransform>().pivot = new Vector2(0.1f, 1.3f);
+        
+        buildText.transform.Translate(50, 0, 0);
+        buildButton = GameObject.Find("BuildButton");
+    }
+
+    public void CreateDestroyButton()
+    {
+        GameObject destroyButton = new GameObject("DestroyButton");
+        destroyButton.transform.parent = GameObject.Find("Canvas").transform;
+
+        destroyButton.AddComponent<Image>();
+        destroyButton.GetComponent<Image>().color = new Color(0, 255, 255, 255);
+        // Image destroyImage = destroyButton.GetComponent<Image>();
+        // destroyImage.type = Image.Type.Sliced;
+
+        destroyButton.AddComponent<Button>();
+        destroyButton.GetComponent<RectTransform>().localPosition = Vector3.zero;
+        destroyButton.GetComponent<RectTransform>().anchorMin = new Vector2(0, 0.54f); //0.54f
+        destroyButton.GetComponent<RectTransform>().anchorMax = new Vector2(0, 0.54f);
+        destroyButton.GetComponent<RectTransform>().pivot = new Vector2(0, 0.54f);
+        destroyButton.GetComponent<RectTransform>().sizeDelta = new Vector2(100, 30);
+        
+        GameObject destroyButtonText = new GameObject("DestroyButtonText");
+        TextMeshProUGUI destroyText = destroyButtonText.AddComponent<TextMeshProUGUI>();
+        destroyText.transform.parent = destroyButton.transform;
+
+        destroyText.text = "\tDestroy";
+        destroyText.color = new Color(0, 0, 0, 255);
+        destroyText.fontSize = 15;
+
+        destroyText.GetComponent<RectTransform>().localPosition = Vector3.zero;
+        destroyText.GetComponent<RectTransform>().anchorMin = new Vector2(0.1f, 1.3f);
+        destroyText.GetComponent<RectTransform>().anchorMax = new Vector2(0.1f, 1.3f);
+        destroyText.GetComponent<RectTransform>().pivot = new Vector2(0.1f, 1.3f);
+        
+        destroyText.transform.Translate(50, 0, 0);
+        destroyButton = GameObject.Find("DestroyButton");
+    }
+
+    public void CreateCancelButton()
+    {
+        GameObject cancelButton = new GameObject("CancelButton");
+        cancelButton.transform.parent = GameObject.Find("Canvas").transform;
+
+        cancelButton.AddComponent<Image>();
+        cancelButton.GetComponent<Image>().color = new Color(255, 0, 0, 255);
+        // Image destroyImage = destroyButton.GetComponent<Image>();
+        // destroyImage.type = Image.Type.Sliced;
+
+        cancelButton.AddComponent<Button>();
+        cancelButton.GetComponent<RectTransform>().localPosition = Vector3.zero;
+        cancelButton.GetComponent<RectTransform>().anchorMin = new Vector2(0, 0.48f); //0.6f
+        cancelButton.GetComponent<RectTransform>().anchorMax = new Vector2(0, 0.48f);
+        cancelButton.GetComponent<RectTransform>().pivot = new Vector2(0, 0.48f);
+        cancelButton.GetComponent<RectTransform>().sizeDelta = new Vector2(100, 30);
+        
+        GameObject cancelButtonText = new GameObject("CancelButtonText");
+        TextMeshProUGUI cancelText = cancelButtonText.AddComponent<TextMeshProUGUI>();
+        cancelText.transform.parent = cancelButton.transform;
+
+        cancelText.text = "\tCancel";
+        cancelText.color = new Color(0, 0, 0, 255);
+        cancelText.fontSize = 15;
+
+        cancelText.GetComponent<RectTransform>().localPosition = Vector3.zero;
+        cancelText.GetComponent<RectTransform>().anchorMin = new Vector2(0.1f, 1.3f);
+        cancelText.GetComponent<RectTransform>().anchorMax = new Vector2(0.1f, 1.3f);
+        cancelText.GetComponent<RectTransform>().pivot = new Vector2(0.1f, 1.3f);
+        
+        cancelText.transform.Translate(50, 0, 0);
+        cancelButton = GameObject.Find("CancelButton");
+    }
+
+    // function to, when the button in the canvas (see line 15) is clicked, toggle the state
+    // of the build options menu
+    // public void ToggleMenu()
+    // {
+    //     if(buildButton.active)
+    //     {
+    //         buildButton.SetActive(false);
+    //     }
+    //     else
+    //     {
+    //         buildButton.SetActive(true);
+    //     }
+    // }
+
+    // public void ToggleDestroyButton()
+    // {
+    //     if(destroyButton.active)
+    //     {
+    //         destroyButton.SetActive(false);
+    //     }
+    //     else
+    //     {
+    //         destroyButton.SetActive(true);
+    //     }
+    // }
+}

--- a/Crypto Wars/Assets/Scripts/GUI/BuildButtonScript.cs
+++ b/Crypto Wars/Assets/Scripts/GUI/BuildButtonScript.cs
@@ -4,63 +4,62 @@ using TMPro;                        //
 using UnityEditor.SearchService;    //
 using UnityEngine;
 using UnityEngine.UI;
+// using UnityEngine.EventSystems;
 
 public class BuildButtonScript : MonoBehaviour
 {
     // public GameObject buildOptionsMenu;
+
     public GameObject destroyButton;
     public GameObject buildButton;
     public GameObject cancelButton;
+
     // Start is called before the first frame update
     void Start()
     {
-        CreateDestroyButton();
         CreateBuildButton();
+        CreateDestroyButton();
         CreateCancelButton();
-
-        if (Input.GetKeyDown(KeyCode.M)) {
-            Debug.Log("Toggling Building Menu");
-            ToggleMenu();
-        }
-        // NOTE: I also created a canvas with a button in it, which is not reflected here
-
-        // TMP_FontAsset font = Resources.Load<TMP_FontAsset>("LiberationSans.ttf");
-
-        // buildOptionsMenu = new GameObject("Build Options", typeof(CanvasRenderer));
-        // buildOptionsMenu.transform.parent = GameObject.Find("Canvas").transform;
-        // // buildOptionsMenu.AddComponent<CanvasRenderer>();
-        // Image image = buildOptionsMenu.AddComponent<Image>();
-        // image.color = new Color(0, 0, 0, 0.5f);
-        
-        // buildOptionsMenu.GetComponent<RectTransform>().localPosition = Vector3.zero;
-        // buildOptionsMenu.GetComponent<RectTransform>().anchorMin = new Vector2(0, 0.5f);
-        // buildOptionsMenu.GetComponent<RectTransform>().anchorMax = new Vector2(0, 0.5f);
-        // buildOptionsMenu.GetComponent<RectTransform>().pivot = new Vector2(0, 0.5f);
-
-        // GameObject temp = new GameObject("Building1_Text");
-        // TextMeshProUGUI building1 = temp.AddComponent<TextMeshProUGUI>();
-        // building1.transform.parent = buildOptionsMenu.transform;
-
-        // building1.GetComponent<RectTransform>().localPosition = Vector3.zero;
-        // building1.GetComponent<RectTransform>().anchorMin = new Vector2(0, 0.5f);
-        // building1.GetComponent<RectTransform>().anchorMax = new Vector2(0, 0.5f);
-        // building1.GetComponent<RectTransform>().pivot = new Vector2(0, 0.5f);
-        // building1.GetComponent<RectTransform>().sizeDelta = new Vector2(95, 50);
-
-        // building1.text = "\t\t Building 1";
-        // building1.font = font;
-        // building1.fontSize = 10;
-
-        // GameObject temp2 = new GameObject("Building2_Button");
-        // Button building2 = temp2.AddComponent<Button>();
-        // // Image image2 = building2.AddComponent<Image>();
-        // building2.transform.parent = buildOptionsMenu.transform;
+        buildButton = GameObject.Find("BuildButton");
+        destroyButton = GameObject.Find("DestroyButton");
+        cancelButton = GameObject.Find("CancelButton");
     }
 
     // Update is called once per frame
     void Update()
     {
+        if (Input.GetKeyDown(KeyCode.M)) {
+            Debug.Log("Toggling Building Menu");
+            ToggleMenu();
+        }
+    }
+    
+    // function to, when the button in the canvas (see line 15) is clicked, toggle the state
+    // of the build options menu
+    public void ToggleMenu()
+    {
+        if(buildButton.GetComponent<Image>().enabled)
+        {
+            buildButton.GetComponent<Image>().enabled = false;
+            buildButton.GetComponentInChildren<TextMeshProUGUI>().enabled = false;
 
+            destroyButton.GetComponent<Image>().enabled = false;
+            destroyButton.GetComponentInChildren<TextMeshProUGUI>().enabled = false;
+
+            cancelButton.GetComponent<Image>().enabled = false;
+            cancelButton.GetComponentInChildren<TextMeshProUGUI>().enabled = false;
+        }
+        else
+        {
+            buildButton.GetComponent<Image>().enabled = true;
+            buildButton.GetComponentInChildren<TextMeshProUGUI>().enabled = true;
+
+            destroyButton.GetComponent<Image>().enabled = true;
+            destroyButton.GetComponentInChildren<TextMeshProUGUI>().enabled = true;
+
+            cancelButton.GetComponent<Image>().enabled = true;
+            cancelButton.GetComponentInChildren<TextMeshProUGUI>().enabled = true;
+        }
     }
 
     public void CreateBuildButton()
@@ -71,7 +70,7 @@ public class BuildButtonScript : MonoBehaviour
         buildButton.AddComponent<Image>();
         buildButton.GetComponent<Image>().color = new Color(0, 255, 0, 255);
         // Image destroyImage = destroyButton.GetComponent<Image>();
-        // destroyImage.type = Image.Type.Sliced;
+        // destroyImage.type = Image.Type.Sliced;                       not needed? maybe later?
 
         buildButton.AddComponent<Button>();
         buildButton.GetComponent<RectTransform>().localPosition = Vector3.zero;
@@ -105,7 +104,7 @@ public class BuildButtonScript : MonoBehaviour
         destroyButton.AddComponent<Image>();
         destroyButton.GetComponent<Image>().color = new Color(0, 255, 255, 255);
         // Image destroyImage = destroyButton.GetComponent<Image>();
-        // destroyImage.type = Image.Type.Sliced;
+        // destroyImage.type = Image.Type.Sliced;                       not needed? maybe later?
 
         destroyButton.AddComponent<Button>();
         destroyButton.GetComponent<RectTransform>().localPosition = Vector3.zero;
@@ -139,7 +138,7 @@ public class BuildButtonScript : MonoBehaviour
         cancelButton.AddComponent<Image>();
         cancelButton.GetComponent<Image>().color = new Color(255, 0, 0, 255);
         // Image destroyImage = destroyButton.GetComponent<Image>();
-        // destroyImage.type = Image.Type.Sliced;
+        // destroyImage.type = Image.Type.Sliced;                       not needed? maybe later?
 
         cancelButton.AddComponent<Button>();
         cancelButton.GetComponent<RectTransform>().localPosition = Vector3.zero;
@@ -162,32 +161,7 @@ public class BuildButtonScript : MonoBehaviour
         cancelText.GetComponent<RectTransform>().pivot = new Vector2(0.1f, 1.3f);
         
         cancelText.transform.Translate(50, 0, 0);
-        cancelButton = GameObject.Find("CancelButton");
+        cancelButton.GetComponent<Button>().onClick.AddListener(ToggleMenu);
+        // cancelButton = GameObject.Find("CancelButton");
     }
-
-    // function to, when the button in the canvas (see line 15) is clicked, toggle the state
-    // of the build options menu
-    // public void ToggleMenu()
-    // {
-    //     if(buildButton.active)
-    //     {
-    //         buildButton.SetActive(false);
-    //     }
-    //     else
-    //     {
-    //         buildButton.SetActive(true);
-    //     }
-    // }
-
-    // public void ToggleDestroyButton()
-    // {
-    //     if(destroyButton.active)
-    //     {
-    //         destroyButton.SetActive(false);
-    //     }
-    //     else
-    //     {
-    //         destroyButton.SetActive(true);
-    //     }
-    // }
 }

--- a/Crypto Wars/Assets/Scripts/GUI/BuildButtonScript.cs.meta
+++ b/Crypto Wars/Assets/Scripts/GUI/BuildButtonScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 143a7a634173da948b65763a8d4dbf36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Crypto Wars/Assets/Scripts/PlayerController.cs
+++ b/Crypto Wars/Assets/Scripts/PlayerController.cs
@@ -40,8 +40,15 @@ public class PlayerController : MonoBehaviour
                     Tile tile = hit.transform.GetComponent<Tile>();
 
                     if (tile != null) {
-                        tile.SetPlayer(CurrentPlayerIndex);
-                        tile.SetMaterial(players[CurrentPlayerIndex].GetColor());
+                        if(tile.GetPlayer() > -1)
+                        {
+                        } 
+                        else
+                        {
+                            tile.SetPlayer(CurrentPlayerIndex);
+                            tile.SetMaterial(players[CurrentPlayerIndex].GetColor());
+                        }
+                      //  Debug.Log("Tile's Player Index is: " + tile.GetPlayer());
                     }
                 }
             }
@@ -49,7 +56,24 @@ public class PlayerController : MonoBehaviour
         // Temp player switching until TurnMaster additions can be made
         if (Input.GetKeyDown(KeyCode.T)) {
             NextPlayer();
-            Debug.Log("Next");
+            Debug.Log("Next: Player Index is now: " + CurrentPlayerIndex);
+        }
+
+        // DEBUG: allows current player to take tile regardless of who owns it
+        if (Input.GetMouseButton(1))
+        {
+            RaycastHit hit;
+            Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+            if (Physics.Raycast(ray, out hit, 100f)) {
+                if (hit.transform != null) {
+                    Tile tile = hit.transform.GetComponent<Tile>();
+
+                    if (tile != null) {
+                        tile.SetPlayer(CurrentPlayerIndex);
+                        tile.SetMaterial(players[CurrentPlayerIndex].GetColor());
+                    }
+                }
+            }
         }
            
     }

--- a/Crypto Wars/Assets/Scripts/PlayerController.cs
+++ b/Crypto Wars/Assets/Scripts/PlayerController.cs
@@ -1,7 +1,9 @@
 using System.Collections;
 using System.Collections.Generic;
+using TMPro;
 using Unity.VisualScripting;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class PlayerController : MonoBehaviour
 {
@@ -42,13 +44,29 @@ public class PlayerController : MonoBehaviour
                     if (tile != null) {
                         if(tile.GetPlayer() > -1)
                         {
+                            if(tile.GetPlayer() == CurrentPlayerIndex)
+                            { 
+                                GameObject buildButton = GameObject.Find("BuildButton");
+                                GameObject destroyButton = GameObject.Find("DestroyButton");
+                                GameObject cancelButton = GameObject.Find("CancelButton");
+                                if(!buildButton.GetComponent<Image>().enabled)
+                                {
+                                    buildButton.GetComponent<Image>().enabled = true;
+                                    buildButton.GetComponentInChildren<TextMeshProUGUI>().enabled = true;
+                                    
+                                    destroyButton.GetComponent<Image>().enabled = true;
+                                    destroyButton.GetComponentInChildren<TextMeshProUGUI>().enabled = true;
+                                    
+                                    cancelButton.GetComponent<Image>().enabled = true;
+                                    cancelButton.GetComponentInChildren<TextMeshProUGUI>().enabled = true;
+                                }
+                            }
                         } 
                         else
                         {
                             tile.SetPlayer(CurrentPlayerIndex);
                             tile.SetMaterial(players[CurrentPlayerIndex].GetColor());
                         }
-                      //  Debug.Log("Tile's Player Index is: " + tile.GetPlayer());
                     }
                 }
             }

--- a/Crypto Wars/Assets/Scripts/TileScript.cs
+++ b/Crypto Wars/Assets/Scripts/TileScript.cs
@@ -31,6 +31,7 @@ public class Tile : MonoBehaviour
         // Materials are loaded with the generic typecast
         BlueMaterial = Resources.Load<Material>("Materials/PlayerTileColor");
         RedMaterial = Resources.Load<Material>("Materials/EnemyTileColor");
+        this.playerIndex = -1;
     }
 
     public int GetPlayer() 


### PR DESCRIPTION
Created three buttons that can appear when a player clicks on a tile that they own. The three buttons are as follows: Create, Destroy, and Cancel. Create and Destroy do not currently do anything, as I do not believe we have the ability for tiles to contain buildings at the moment. Cancel simply hides the three buttons, resulting in an unobstructed user interface.

Addresses part of Issue #27 

I also added a debug tool to PlayerController that will allow a player to take ownership of a tile forcefully. This is purely for testing purposes, and obviously should be removed before shipping. 
I also made tiles start with a playerIndex of -1 to indicate that they are unowned, which may be helpful in the future.

