### PR TITLE
Add functionality for Victory Screen

### DIFF
--- a/Crypto Wars/Assets/Scripts/GUI/VictoryScreen.cs
+++ b/Crypto Wars/Assets/Scripts/GUI/VictoryScreen.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class VictoryScreen : MonoBehaviour
+{
+    public WinConditions wcScript;
+    private GameObject Panel;
+    private Boolean gameOver;
+    private Image image;
+    
+    // Start is called before the first frame update
+    void Start()
+    {
+        gameOver = false;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if(!gameOver){ // prevent infinite insantiation of victory screen
+            if(wcScript.winningPlayer != null){
+                gameOver = true;
+                displayVictoryGUI();
+            }
+        }        
+    }
+
+
+    void displayVictoryGUI(){
+        GameObject Canvas = GameObject.Find("Canvas");
+        Player winner = wcScript.winningPlayer;
+
+        // create the panel which displays all needed information
+        Panel = new GameObject("VictoryPanel");
+        Panel.transform.parent = Canvas.transform;
+        Panel.AddComponent<CanvasRenderer>();
+        Panel.AddComponent<GraphicRaycaster>();
+        image = Panel.AddComponent<Image>();
+        image.color = new Color(0, 0, 0, 1);
+
+        // fix panel to middle of screen
+        Panel.GetComponent<RectTransform>().localPosition = new Vector3(0, 0, 0);
+        Panel.GetComponent<RectTransform>().sizeDelta = new Vector2(700, 350);
+        Panel.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+
+        // Create/align/display winner text
+        GameObject text = new GameObject("WinnerText");
+        text.transform.parent = Panel.transform;
+        TextMeshProUGUI winnerText = text.AddComponent<TextMeshProUGUI>();
+        winnerText.GetComponent<RectTransform>().anchoredPosition = new Vector2(0, 125);
+        winnerText.alignment = TextAlignmentOptions.Center;
+        winnerText.color = winner.GetColor().color;
+        winnerText.text = "Player " + winner.GetName() + " Wins!";
+
+        // Create/align/display stats text
+        text = new GameObject("StatsText");
+        text.transform.parent = Panel.transform;
+        TextMeshProUGUI statsText = text.AddComponent<TextMeshProUGUI>();
+        statsText.GetComponent<RectTransform>().sizeDelta = new Vector2(700, 350);
+        statsText.GetComponent<RectTransform>().anchoredPosition = new Vector2(0, -50);
+        statsText.alignment = TextAlignmentOptions.Center;
+        statsText.text = "Tiles Controlled:\t\t% Controlled\n" + winner.getTilesControlledCount() + "\t\t\t\t" + winner.CalculatePercentage() + "%";
+    }
+}

--- a/Crypto Wars/Assets/Scripts/Test_EditMode/VictoryScreenTest.cs
+++ b/Crypto Wars/Assets/Scripts/Test_EditMode/VictoryScreenTest.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+
+public class VictoryScreenTest
+{
+    GameObject panel;
+    VictoryScreen vs;
+
+    [SetUp]
+    public void SetUp()
+    {
+        panel = new GameObject("VictoryScreen");
+        panel.AddComponent<VictoryScreen>();
+        vs = panel.GetComponent<VictoryScreen>();
+        vs.transform.localPosition = Vector3.zero;
+    }
+
+    [Test]
+    public void TestGUIdisplay()
+    {
+        Assert.AreEqual(Vector3.zero, panel.transform.localPosition);
+    }
+}


### PR DESCRIPTION
## Describe your changes
<!--- Detail the changes and possible issues that may arise -->
Adds functionality for Victory Screen which is displayed on the canvas once a winner is declared in the WinConditions.cs script via the winningPlayer field. The victory screen also displays game statistics for the winner such as the total number of tiles and the percentage they control.

## Issue number and link
Solves issue [#81](https://github.com/UNLV-CS472-672/2024-S-GROUP8-CW/issues/81)

## Screenshots (if appropriate):
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP8-CW/assets/143847490/e2c924ac-b359-40eb-9090-6e221ebf1535)

## Types of changes
- [ ] Bug fix (fixes a issue)
- [x] New feature (new implemention of a feature)
- [ ] Refactoring (small changes that won't impact very much)
- [ ] Possible broken change (fix or feature that could break functionality)

## Checklist:
- [x] Have added comments and documentation
- [x] You have tested all the code thoroughly 
- [x] I have added tests to cover my changes. 
   Or have added an issue that tests need to be added.
- [x] If scene changes were made were they in a separate scene (Doesn't apply to CodingAdam)