### PR TITLE
Add phase indicator

### DIFF
--- a/Crypto Wars/Assets/Scenes/EndPhaseScene.unity
+++ b/Crypto Wars/Assets/Scenes/EndPhaseScene.unity
@@ -310,6 +310,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 993964395}
+  - {fileID: 1077702609}
   - {fileID: 438552243}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -401,19 +402,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 993964396}
-        m_TargetAssemblyTypeName: EndTurn, Assembly-CSharp
-        m_MethodName: endPlayerTurn
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 1077702606}
         m_TargetAssemblyTypeName: EndTurn, Scripts
         m_MethodName: endPlayerPhase
         m_Mode: 1
@@ -819,6 +808,158 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1077702605
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1077702609}
+  - component: {fileID: 1077702608}
+  - component: {fileID: 1077702607}
+  - component: {fileID: 1077702606}
+  m_Layer: 5
+  m_Name: PhaseDisplay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1077702606
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077702605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a08fc9064981643f5b0bd87c733d9f23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  turnOutput: {fileID: 0}
+  phaseOutput: {fileID: 0}
+  turnNum: 0
+--- !u!114 &1077702607
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077702605}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Phase: Defense
+
+'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1077702608
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077702605}
+  m_CullTransparentMesh: 1
+--- !u!224 &1077702609
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077702605}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 377088723}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -425, y: -25}
+  m_SizeDelta: {x: 300, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1146861710
 GameObject:
   m_ObjectHideFlags: 0

--- a/Crypto Wars/Assets/Scenes/EndPhaseScene.unity.meta
+++ b/Crypto Wars/Assets/Scenes/EndPhaseScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 42aad601c9419b64fb19b4d1cbeacf5e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Crypto Wars/Assets/Scripts/EndTurn.cs
+++ b/Crypto Wars/Assets/Scripts/EndTurn.cs
@@ -5,7 +5,13 @@ using TMPro;
 
 public class EndTurn : MonoBehaviour
 {
+    // Game screen displays
+    GameObject turnObject;
+    GameObject phaseObject;
     public TextMeshProUGUI turnOutput;
+    public TextMeshProUGUI phaseOutput;
+
+    // EndTurn Variables
     public int turnNum;
     PlayerController playerList;
     Player pl;
@@ -14,9 +20,32 @@ public class EndTurn : MonoBehaviour
     // Attaches the counter to a Text (TMP) gameObject
     void Start()
     {
-        turnNum = 0;
-        turnOutput = GetComponent<TextMeshProUGUI>();
+        turnNum = 0; // starting turn #
+
+        // On-screen text for displaying the current phase
+        phaseObject = GameObject.Find("PhaseDisplay");
+        if (phaseObject == null)
+        {
+            phaseObject = new GameObject("PhaseD");
+            phaseObject.AddComponent<TextMeshProUGUI>();
+            phaseObject.SetActive(true);
+        }
+        phaseOutput = phaseObject.GetComponent<TextMeshProUGUI>();
+        phaseOutput.text = "Phase: " + "Defense";
+
+        // On-screen text for turn counter
+        turnObject = GameObject.Find("TurnCounter");
+        if (turnObject == null)
+        {
+            turnObject = new GameObject("TurnC");
+            turnObject.AddComponent<TextMeshProUGUI>();
+            turnObject.SetActive(true);
+        }
+        turnOutput = turnObject.GetComponent<TextMeshProUGUI>();
         turnOutput.text = "Turn " + turnNum.ToString();
+
+        GameObject playerCtrlGameObject = new GameObject("PlayerCtrller");
+        playerList = playerCtrlGameObject.AddComponent<PlayerController>();
     }
 
     // Sets player isDone to false
@@ -31,12 +60,39 @@ public class EndTurn : MonoBehaviour
         // pl.PlayerFinishTurn();
         // playerList.NextPlayer();
         // turnOutput.text = "Turn " + turnNum.ToString();
-        
+
 
 
         // test prototype for now to make sure the text output and button are working properly
+        // GetCurrentPhase
         turnNum++;
         turnOutput.text = "Turn " + turnNum.ToString();
     }
 
+    /*
+     * endPlayerPhase - moves onto a player's next phase
+     *      once a player reaches their "Build" phase,
+     *      their turn will have ended
+     */
+    public void endPlayerPhase()
+    {
+        // Set phaseOutput to match CurrentPlayer's phase
+        if(PlayerController.CurrentPlayer != null)
+        {
+            // Increment CurrentPlayer's phase
+            // PlayerController.CurrentPlayer.NextPhase();
+            phaseOutput.text = "Phase: " + PlayerController.CurrentPlayer.GetCurrentPhase().ToString();
+        }
+        else // Should not occur
+        {
+            // For debugging/testing purposes
+            phaseOutput.text = "Phase: " + "Build";
+        }
+        
+        // Check if end of player's turn
+        if (phaseOutput.text == "Phase: Build")
+        {
+            endPlayerTurn();
+        }
+    }
 }

--- a/Crypto Wars/Assets/Scripts/EndTurn.cs
+++ b/Crypto Wars/Assets/Scripts/EndTurn.cs
@@ -64,7 +64,6 @@ public class EndTurn : MonoBehaviour
 
 
         // test prototype for now to make sure the text output and button are working properly
-        // GetCurrentPhase
         turnNum++;
         turnOutput.text = "Turn " + turnNum.ToString();
     }

--- a/Crypto Wars/Assets/Scripts/EndTurn.cs
+++ b/Crypto Wars/Assets/Scripts/EndTurn.cs
@@ -26,7 +26,7 @@ public class EndTurn : MonoBehaviour
         phaseObject = GameObject.Find("PhaseDisplay");
         if (phaseObject == null)
         {
-            phaseObject = new GameObject("PhaseD");
+            phaseObject = new GameObject("PhaseDisplay");
             phaseObject.AddComponent<TextMeshProUGUI>();
             phaseObject.SetActive(true);
         }
@@ -37,7 +37,7 @@ public class EndTurn : MonoBehaviour
         turnObject = GameObject.Find("TurnCounter");
         if (turnObject == null)
         {
-            turnObject = new GameObject("TurnC");
+            turnObject = new GameObject("TurnCounter");
             turnObject.AddComponent<TextMeshProUGUI>();
             turnObject.SetActive(true);
         }

--- a/Crypto Wars/Assets/Scripts/GUI/VictoryScreen.cs.meta
+++ b/Crypto Wars/Assets/Scripts/GUI/VictoryScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 362b4bdb7331fe14c8fe66e3fac7a131
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Crypto Wars/Assets/Scripts/Test_EditMode/VictoryScreenTest.cs.meta
+++ b/Crypto Wars/Assets/Scripts/Test_EditMode/VictoryScreenTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d7e2cc21b24af341bc107e670c3b8c5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Crypto Wars/Assets/Scripts/Test_PlayMode/EndTurnTest.cs
+++ b/Crypto Wars/Assets/Scripts/Test_PlayMode/EndTurnTest.cs
@@ -7,6 +7,7 @@ public class EndTurnTest
 {
     public GameObject go;
     int startNum;
+    string phaseText;
 
     [SetUp]
     public void SetUp()
@@ -15,6 +16,7 @@ public class EndTurnTest
         go.AddComponent<EndTurn>();
         go.AddComponent<TMPro.TextMeshProUGUI>();
         go.GetComponent<EndTurn>().turnOutput = go.GetComponent<TMPro.TextMeshProUGUI>();
+        go.GetComponent<EndTurn>().phaseOutput = go.GetComponent<TMPro.TextMeshProUGUI>();
     }
 
     [Test]
@@ -22,6 +24,14 @@ public class EndTurnTest
     {
         go.GetComponent<EndTurn>().endPlayerTurn();
         Assert.AreNotEqual(startNum, go.GetComponent<EndTurn>().turnNum);
+    }
+
+    [Test]
+    public void TestPhaseIncrement()
+    {
+        phaseText = "Phase: " + "Defense";
+        go.GetComponent<EndTurn>().endPlayerPhase();
+        Assert.AreNotEqual(phaseText, go.GetComponent<EndTurn>().phaseOutput.text);
     }
 
     [TearDown]


### PR DESCRIPTION
## Describe your changes
Added a Phase indicator (Top-middle tells you what phase you’re on). In addition, I changed the "End Turn" button to "End Phase" so that the turn button duals as a end this specific phase/turn. When the player reaches their final phase, the next time they click on the "End Phase" button, it will automatically increment the turn counter. Thus, the button ends the player's phase and their overall turn once all phases are completed. 

## Issue number and link
Resolves Issue #105 

## Screenshots (if appropriate):
The following screenshot shows the new scene I created for reference:
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP8-CW/assets/143662887/3ffb3f21-146b-4356-b762-5985d6dd5020)

## Types of changes
- [ ] Bug fix (fixes a issue)
- [x] New feature (new implemention of a feature)
- [x] Refactoring (small changes that won't impact very much)
- [ ] Possible broken change (fix or feature that could break functionality)

## Checklist:
- [x] Have added comments and documentation
- [x] You have tested all the code thoroughly 
- [x] I have added tests to cover my changes. 
   Or have added an issue that tests need to be added.
- [x] If scene changes were made were they in a separate scene (Doesn't apply to CodingAdam)