### PR TITLE
Extends Code Coverage for PlayerScript and TileScript

### DIFF
--- a/Crypto Wars/Assets/Scripts/GUI/HandManager.cs.meta
+++ b/Crypto Wars/Assets/Scripts/GUI/HandManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 109b119d472ad8a4e9d454e6a7878aa9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Crypto Wars/Assets/Scripts/Test_EditMode/PlayerScriptTest.cs
+++ b/Crypto Wars/Assets/Scripts/Test_EditMode/PlayerScriptTest.cs
@@ -102,4 +102,46 @@ public class PlayerScriptTest
         Assert.AreEqual(p1.GetTiles().Count, 1);
         Assert.AreEqual(p1.getTilesControlledCount(), 1);
     }
+
+    [Test]
+    public void PlayerScript_AddTilesOverloaded_Test()
+    {
+        int playerTiles = player.GetTiles().Count;
+        List<Tile.TileReference> tiles = new List<Tile.TileReference>()
+        {
+            new Tile.TileReference { tilePosition = new Vector2(0,0), tileName = "Tile1" },
+            new Tile.TileReference { tilePosition = new Vector2(1,0), tileName = "Tile2" }
+        };
+
+        player.AddTiles(tiles, 2);
+        Assert.AreEqual(player.GetTiles().Count, playerTiles + 2);
+    }
+
+    [Test]
+    public void PlayerScript_RemoveTiles_Test()
+    {
+        List<Tile.TileReference> tiles = new List<Tile.TileReference>()
+        {
+            new Tile.TileReference { tilePosition = new Vector2(0,0), tileName = "Tile1" },
+            new Tile.TileReference { tilePosition = new Vector2(1,0), tileName = "Tile2" }
+        };
+
+        player.AddTiles(tiles, 2);
+        player.RemoveTiles(tiles[0]);
+        Assert.AreEqual(player.GetTiles().Count, 1);
+    }
+
+    [Test]
+    public void PlayerScript_RemoveTilesOverloaded_Test()
+    {
+        List<Tile.TileReference> tiles = new List<Tile.TileReference>()
+        {
+            new Tile.TileReference { tilePosition = new Vector2(0,0), tileName = "Tile1" },
+            new Tile.TileReference { tilePosition = new Vector2(1,0), tileName = "Tile2" }
+        };
+
+        player.AddTiles(tiles, 2);
+        player.RemoveTiles(tiles, 2);
+        Assert.AreEqual(player.GetTiles().Count, 0);
+    }
 }

--- a/Crypto Wars/Assets/Scripts/Test_EditMode/PlayerScriptTest.cs
+++ b/Crypto Wars/Assets/Scripts/Test_EditMode/PlayerScriptTest.cs
@@ -106,6 +106,7 @@ public class PlayerScriptTest
     [Test]
     public void PlayerScript_AddTilesOverloaded_Test()
     {
+        // Test to ensure that the AddTiles method adds the correct number of tiles
         int playerTiles = player.GetTiles().Count;
         List<Tile.TileReference> tiles = new List<Tile.TileReference>()
         {
@@ -120,6 +121,7 @@ public class PlayerScriptTest
     [Test]
     public void PlayerScript_RemoveTiles_Test()
     {
+        // Test to ensure that the RemoveTiles method removes the correct number of tiles
         List<Tile.TileReference> tiles = new List<Tile.TileReference>()
         {
             new Tile.TileReference { tilePosition = new Vector2(0,0), tileName = "Tile1" },
@@ -134,6 +136,7 @@ public class PlayerScriptTest
     [Test]
     public void PlayerScript_RemoveTilesOverloaded_Test()
     {
+        // Test to ensure that the RemoveTiles method removes the correct number of tiles
         List<Tile.TileReference> tiles = new List<Tile.TileReference>()
         {
             new Tile.TileReference { tilePosition = new Vector2(0,0), tileName = "Tile1" },

--- a/Crypto Wars/Assets/Scripts/Test_PlayMode/TileScriptTest.cs
+++ b/Crypto Wars/Assets/Scripts/Test_PlayMode/TileScriptTest.cs
@@ -56,6 +56,54 @@ namespace Test
             Assert.AreEqual(expectedPosition, tile.GetTilePosition());
         }
 
+        [Test]
+        public void Tile_GetBuilding_ReturnsCorrectBuilding()
+        {
+            // Test to ensure the building is retrieved correctly
+            Building building = tile.GetBuilding();
+            string buildingName = building.getName();
+            Assert.AreEqual("Nothing", building.name);
+
+        }
+        [Test]
+        public void Tile_SetBuilding_AssignsBuildingCorrectly()
+        {
+            // Test to ensure the building is set correctly
+            Building testBuilding = new Building("TestBuilding", 1, 1);
+            tile.SetBuilding(testBuilding);
+            Building actualBuilding = tile.GetBuilding();
+            Assert.AreEqual(testBuilding, actualBuilding);
+        }
+
+        [Test]
+        public void Tile_IsAdjacent_ReturnsTrue()
+        {
+            Player player = new Player("One", Resources.Load<Material>("Materials/PlayerTileColor"));
+            player.AddTiles(new Tile.TileReference { tilePosition = new Vector2(0,0), tileName = "Tile"});
+            player.AddTiles(new Tile.TileReference { tilePosition = new Vector2(1,0), tileName = "Tile2"});
+
+            Tile adjTile = new Tile();
+            adjTile.SetTilePosition(0,1);
+
+            bool checkTile = Tile.IsAdjacent(player, adjTile);
+            Assert.IsTrue(checkTile);
+
+            adjTile.SetTilePosition(1,0);
+
+            checkTile = Tile.IsAdjacent(player, adjTile);
+            Assert.IsTrue(checkTile);
+
+            adjTile.SetTilePosition(0,0);
+            checkTile = Tile.IsAdjacent(player, adjTile);
+            Assert.IsFalse(checkTile);
+        }
+
+        [Test]
+        public void Tile_GetRender_ReturnsRender()
+        {
+            // Test to ensure the render is retrieved correctly
+        }
+
         [TearDown]
         public void TearDown()
         {

--- a/Crypto Wars/Assets/Scripts/Test_PlayMode/TileScriptTest.cs
+++ b/Crypto Wars/Assets/Scripts/Test_PlayMode/TileScriptTest.cs
@@ -78,6 +78,8 @@ namespace Test
         [Test]
         public void Tile_IsAdjacent_ReturnsTrue()
         {
+            // Test to ensure the tile is adjacent to the player
+            // Create a player and add tiles to it
             Player player = new Player("One", Resources.Load<Material>("Materials/PlayerTileColor"));
             player.AddTiles(new Tile.TileReference { tilePosition = new Vector2(0,0), tileName = "Tile"});
             player.AddTiles(new Tile.TileReference { tilePosition = new Vector2(1,0), tileName = "Tile2"});
@@ -85,6 +87,7 @@ namespace Test
             Tile adjTile = new Tile();
             adjTile.SetTilePosition(0,1);
 
+            // Check if the tile is adjacent to the player
             bool checkTile = Tile.IsAdjacent(player, adjTile);
             Assert.IsTrue(checkTile);
 


### PR DESCRIPTION
Extends test coverage for PlayerScript and TileScript. Although in my previous PR I had decent results generating Unit tests with ChatGPT, I found it completely annoying to use this time around and decided to not use it at all because it was wasting more time than saving with it's nonsense recommendations.

## Describe your changes
<!--- Detail the changes and possible issues that may arise -->
Added PlayMode coverage for remaining TileScript methods and EditMode coverage for remaining PlayerScript methods.
## Issue number and link
<!--- Example #1 and https://github.com/.../.../issues/1 -->
#114 
## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (fixes a issue)
- [ ] New feature (new implemention of a feature)
- [ ] Refactoring (small changes that won't impact very much)
- [ ] Possible broken change (fix or feature that could break functionality)
- [x] Test Coverage

## Checklist:
- [x] Have added comments and documentation
- [x] You have tested all the code thoroughly 
- [x] I have added tests to cover my changes. 
   Or have added an issue that tests need to be added.
- [x] If scene changes were made were they in a separate scene (Doesn't apply to CodingAdam)